### PR TITLE
Added image argument completers for: Repository, Tag and Name

### DIFF
--- a/src/Internal/ImageParameterCompleters.ps1
+++ b/src/Internal/ImageParameterCompleters.ps1
@@ -1,0 +1,54 @@
+$RepositoryCompleter = {
+    param (
+        $commandName,
+        $parameterName,
+        $wordToComplete,
+        $commandAst,
+        $fakeBoundParameters
+    )
+
+    return Get-DockerImage | Select-Object -ExpandProperty Repository -Unique
+}
+
+Set-Variable -Name RepositoryCompleter -Value $RepositoryCompleter -Visibility Public -Scope Script
+
+$TagCompleter = {
+    param (
+        $commandName,
+        $parameterName,
+        $wordToComplete,
+        $commandAst,
+        $fakeBoundParameters
+    )
+
+    $possibleValues = Get-DockerImage
+
+    if ($fakeBoundParameters.ContainsKey('Repository')) {
+        $Repository = $fakeBoundParameters.Repository
+
+        $possibleValues | Where-Object -FilterScript {
+            $_.Repository -eq $Repository
+        } | Where-Object -FilterScript {
+            $_.Tag
+        } | Select-Object -ExpandProperty Tag
+    }
+    else {
+        $possibleValues.Values | ForEach-Object { $_ }
+    }
+}
+
+Set-Variable -Name TagCompleter -Value $TagCompleter -Visibility Public -Scope Script
+
+$NameCompleter = {
+    param (
+        $commandName,
+        $parameterName,
+        $wordToComplete,
+        $commandAst,
+        $fakeBoundParameters
+    )
+
+    return Get-DockerImage | Select-Object -ExpandProperty ImageName -Unique
+}
+
+Set-Variable -Name NameCompleter -Value $NameCompleter -Visibility Public -Scope Script

--- a/src/PSDocker.psm1
+++ b/src/PSDocker.psm1
@@ -1,4 +1,4 @@
-foreach ( $folder in @('Public', 'Internal') ) {
+foreach ( $folder in @('Internal', 'Public') ) {
     $folderPath = Join-Path -Path $PSScriptRoot -ChildPath $folder
     if (Test-Path -Path $folderPath) {
         Write-Verbose "Importing from $folder"

--- a/src/Public/Get-Image.ps1
+++ b/src/Public/Get-Image.ps1
@@ -1,3 +1,6 @@
+Register-ArgumentCompleter -CommandName Get-DockerImage -ParameterName Repository -ScriptBlock $RepositoryCompleter
+Register-ArgumentCompleter -CommandName Get-DockerImage -ParameterName Tag -ScriptBlock $TagCompleter
+
 function Get-Image {
 
     <#
@@ -57,7 +60,8 @@ function Get-Image {
         if ( $Repository ) {
             if ( $Tag ) {
                 $arguments.Add( $Repository + ':' + $Tag ) | Out-Null
-            } else {
+            }
+            else {
                 $arguments.Add( $Repository ) | Out-Null
             }
         }
@@ -66,10 +70,10 @@ function Get-Image {
         ForEach-Object {
             New-Object -TypeName Image -Property @{
                 Repository = $_.Repository
-                Tag = switch ( $_.Tag ) { '<none>' { $null } default { $_ } }
-                Id = $_.ID
-                CreatedAt = $_.CreatedAt
-                Size = $_.Size
+                Tag        = switch ( $_.Tag ) { '<none>' { $null } default { $_ } }
+                Id         = $_.ID
+                CreatedAt  = $_.CreatedAt
+                Size       = $_.Size
             } | Write-Output
         } | Write-Output
 

--- a/src/Public/Install-Image.ps1
+++ b/src/Public/Install-Image.ps1
@@ -1,3 +1,6 @@
+Register-ArgumentCompleter -CommandName Install-DockerImage -ParameterName Repository -ScriptBlock $RepositoryCompleter
+Register-ArgumentCompleter -CommandName Install-DockerImage -ParameterName Tag -ScriptBlock $TagCompleter
+
 function Install-Image {
 
     <#

--- a/src/Public/Uninstall-Image.ps1
+++ b/src/Public/Uninstall-Image.ps1
@@ -1,3 +1,5 @@
+Register-ArgumentCompleter -CommandName Uninstall-DockerImage -ParameterName Name -ScriptBlock $NameCompleter
+
 function Uninstall-Image {
 
     <#


### PR DESCRIPTION
This PR adds dynamic parameter values for: Repository, Tag and Name. This is currently available only on the following functions: `Get-DockerImage`, `Install-DockerImage` and `Uninstall-DockerImage`. To use this feature, simply hit the `Tab` key after, for instance, `Get-DockerImage -Repository ` is typed in the CLI.

@abbgrade, feel free to make modifications if needed. Thanks for this module!